### PR TITLE
disable dependabot for compile time dependencies of runtime library

### DIFF
--- a/runtime-common/build.gradle.kts
+++ b/runtime-common/build.gradle.kts
@@ -18,10 +18,11 @@ repositories {
 }
 
 dependencies {
-    compileOnly("net.minecraft:launchwrapper:1.12")
-    compileOnly("org.apache.logging.log4j:log4j-api:2.0")
-    compileOnly("org.ow2.asm:asm:6.0")
-    compileOnly("lzma:lzma:0.0.1")
+    val empty = ""
+    compileOnly("net.minecraft$empty:launchwrapper:1.12")
+    compileOnly("org.apache.logging.log4j$empty:log4j-api:2.0")
+    compileOnly("org.ow2.asm$empty:asm:6.0")
+    compileOnly("lzma$empty:lzma:0.0.1")
     compileOnly(files(rootProject.tasks.createCompileTimeConstant.get().output)
         .builtBy(rootProject.tasks.createCompileTimeConstant))
 

--- a/runtime-fml-in-cpw/build.gradle.kts
+++ b/runtime-fml-in-cpw/build.gradle.kts
@@ -21,12 +21,13 @@ repositories {
 }
 
 dependencies {
+    val empty = ""
     //compileOnly("net.minecraftforge:forge:1.6.2-9.10.1.871:universal")
-    compileOnly("net.minecraftforge:forge:1.7.10-10.13.4.1614-1.7.10:universal")
-    compileOnly("net.minecraft:launchwrapper:1.12")
-    compileOnly("org.apache.logging.log4j:log4j-api:2.0")
-    compileOnly("org.ow2.asm:asm-debug-all:5.0.3")
-    compileOnly("lzma:lzma:0.0.1")
+    compileOnly("net.minecraftforge$empty:forge:1.7.10-10.13.4.1614-1.7.10:universal")
+    compileOnly("net.minecraft$empty:launchwrapper:1.12")
+    compileOnly("org.apache.logging.log4j$empty:log4j-api:2.0")
+    compileOnly("org.ow2.asm$empty:asm-debug-all:5.0.3")
+    compileOnly("lzma$empty:lzma:0.0.1")
     compileOnly(files(rootProject.tasks.createCompileTimeConstant.get().output)
         .builtBy(rootProject.tasks.createCompileTimeConstant))
     compileOnly(project(":runtime-common"))

--- a/runtime-fml-in-forge/build.gradle.kts
+++ b/runtime-fml-in-forge/build.gradle.kts
@@ -19,11 +19,12 @@ repositories {
 
 dependencies {
     //compileOnly("net.minecraftforge:forge:1.12.2-14.23.5.2855:universal")
-    compileOnly("net.minecraftforge:forge:1.8-11.14.4.1577:universal")
-    compileOnly("net.minecraft:launchwrapper:1.12")
-    compileOnly("org.apache.logging.log4j:log4j-api:2.8.1")
-    compileOnly("org.ow2.asm:asm:6.0")
-    compileOnly("lzma:lzma:0.0.1")
+    val empty = ""
+    compileOnly("net.minecraftforge$empty:forge:1.8-11.14.4.1577:universal")
+    compileOnly("net.minecraft$empty:launchwrapper:1.12")
+    compileOnly("org.apache.logging$empty.log4j:log4j-api:2.8.1")
+    compileOnly("org.ow2.asm$empty:asm:6.0")
+    compileOnly("lzma$empty:lzma:0.0.1")
     compileOnly(files(rootProject.tasks.createCompileTimeConstant.get().output)
         .builtBy(rootProject.tasks.createCompileTimeConstant))
     compileOnly(project(":runtime-common"))


### PR DESCRIPTION
Because compile time dependencies of runtime library are of Minecraft and Minecraft Forge so their version should not be changed.